### PR TITLE
Add Bitwarden and MacPass bundle identifiers

### DIFF
--- a/Yippy/Sources/Models/History/History.swift
+++ b/Yippy/Sources/Models/History/History.swift
@@ -74,6 +74,7 @@ class History {
         "com.bitwarden.desktop",
         "com.8bit.bitwarden",
         "com.hicknhacksoftware.MacPass",
+        "com.keepassium.ios",
     ]
     /// These pasteboard item types will not be saved.
     private let pasteboardTypeIgnoreList = Set([

--- a/Yippy/Sources/Models/History/History.swift
+++ b/Yippy/Sources/Models/History/History.swift
@@ -71,6 +71,9 @@ class History {
         "de.petermaurer.TransientPasteboardType",
         "Pasteboard generator type",
         "net.antelle.keeweb",
+        "com.bitwarden.desktop",
+        "com.8bit.bitwarden",
+        "com.hicknhacksoftware.MacPass",
     ]
     /// These pasteboard item types will not be saved.
     private let pasteboardTypeIgnoreList = Set([


### PR DESCRIPTION
In the exclusion list (pasteboardTypeDenylist), same strategy as in https://github.com/mattDavo/Yippy/pull/56.

Connected to https://github.com/mattDavo/Yippy/issues/26

Saidly I coud not find the bundle identifiers for https://github.com/mattDavo/Yippy/issues/63